### PR TITLE
add japanese section 4.1

### DIFF
--- a/section_4 _ja/4.1.md
+++ b/section_4 _ja/4.1.md
@@ -1,0 +1,105 @@
+# セクション 4.1 論理型
+
+言語仕様を見て、プログラミング言語の専門用語に精通しておくのは重要な事です。そうしておくと、言語や他の人達との議論でも正確な理解に結びつきます。また、言語のデザインをどうしたかったのかを理解するのはとても大事なことです。[Go言語仕様](https://golang.org/ref/spec)を後で見ていきましょう。
+
+このセクションでは、Goで異なる型を見ていきます。[論理型](https://golang.org/ref/spec#Boolean_types)を見ていきましょう。
+
+```
+uint8       符号なし8bit整数セット  (0 to 255)
+uint16      符号なし16bit整数セット (0 to 65535)
+uint32      符号なし32bit整数セット (0 to 4294967295)
+uint64      符号なし64bit整数セット (0 to 18446744073709551615)
+
+int8        符号あり8bit整数セット  (-128 to 127)
+int16       符号あり16bit整数セット (-32768 to 32767)
+int32       符号あり32bit整数セット (-2147483648 to 2147483647)
+int64       符号あり64bit整数セット (-9223372036854775808 to 9223372036854775807)
+
+float32     IEEE-754 32bit浮動小数値セット
+float64     IEEE-754 64bit浮動小数値セット
+
+complex64   float32の実数部と虚数部を持つ複素数
+complex128  float64の実数部と虚数部を持つ複素数
+
+byte        uint8の別名
+rune        int32の別名
+```  
+
+論理値は`true`か`false`をとります。[「論理(boolean)」を検索](https://www.google.ca/search?q=define%3A+boolean&rlz=1C5CHFA_enCA702CA702&oq=define%3A+boolean&aqs=chrome..69i57j69i58.3231j0j7&sourceid=chrome&ie=UTF-8)してみると、「特にコンピューターとエレクトロニクスの分野において、論理値を表現するために使われる記法を意味する」とか「`true`か`false`のどちらかを取るバイナリ値」などと定義されています。
+
+論理値はそういうものです。`true`か`false`です。プログラミングにおいてとても重要な役割を持っています。論理値は評価を`true`か`false`落とし込むことができるようにしてくれたり、条件分岐に使えます。何かが`true`の場合にはやることがひとつ決まっており、`false`の場合はそれ以外という感じです。
+
+このコースの後で、条件分岐やswitch文、if文などシーケンシャルなフローや繰り返しのフローなどを見ていきます。
+
+今は、`Boolean`の続きを見ていきましょう。
+
+Goでは、`bool(論理値)`は型です。`bool`型の`x`を宣言してみましょう。
+  
+```go
+var x bool
+```
+
+`var` `x`の_型_は`bool`です。`x`は`bool`_型_の_値を保持_しています。変数`x`を宣言しましたが、、値を割り当てていません。つまり`x`を出力すると、_ゼロ値_が帰ります。`bool`型のゼロ値は`false`です。
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+var x bool
+
+func main() {
+	fmt.Println(x)
+}
+```
+
+[playground](https://play.golang.org/p/QuKLHA2JYG)  
+
+Goでは行末にセミコロンを入れないことを変に思う人もいます。実はセミコロンはコンパイラがこっそり付け加えています。なので、`x = true;`ではなく、`x = true`で大丈夫なのです。Goは_プログラミングを楽すること_に注力しています。効率的なコンパイル、楽なプログラミング、効率的な実行です。
+
+```go
+package main
+
+import (
+	"fmt"
+)
+
+var x bool
+
+func main() {
+	fmt.Println(x)
+	x = true
+	fmt.Println(x)
+}
+```
+
+論理値に対しては評価や比較もできますし、返り値に`bool`もとることができます。[演算子とデリミタ](https://golang.org/ref/spec#Operators_and_Delimiters)を見てみると、二重イコール`==`、小なりイコール`<=`、大なりイコール`>=`、大なり`>`、小なり`<`のような比較のための演算子があるのが分かります。
+
+実験してみましょう。短縮形宣言演算子を使い、`a`に`7`、`b`に`47`を割り当ててみて下さい。その後、`a`と`b`を`a == b`として比較してください。
+  
+```go
+package main
+
+import (
+	"fmt"
+)
+
+var x bool
+
+func main() {
+	a := 7 // これを42に変えると、a == bがtrueになります
+	b := 42
+	fmt.Println(a == b) // <=, >=, !=, >, <といった演算子で実験してみてください
+}
+```
+
+[playground](https://play.golang.org/p/NVq6m0_Rzi)  
+
+Goでは二重イコール演算子`==`は同一かどうかを比較します。ひとつのイコール`=`は割り当てに使います。
+
+[論理型](https://golang.org/ref/spec#Boolean_types)の言語仕様では以下のように書かれています。
+
+論理型は前に述べたように`true`か`false`で記述される真偽値を表す。論理型は論理値である。
+

--- a/section_4/4.1.md
+++ b/section_4/4.1.md
@@ -76,7 +76,7 @@ func main() {
 
 We can also do evaluations, or compare things, and get a `bool` in return. If we look at the [operators and delimiters](https://golang.org/ref/spec#Operators_and_Delimiters), we have some operators which allow us to do comparisons such as double equality `==`, less than or equal to`<=`, greater than or equal to `>=`, or greater than `>` and less than `<`, not equal `!=`, etc.  
   
-Let's try some out. Using the short declaration operator, let's assign values to a couple of variables `a :=` 7`, and `b := 42`, then see if they are equal to each other `a == b`.  
+Let's try some out. Using the short declaration operator, let's assign values to a couple of variables `a := 7`, and `b := 42`, then see if they are equal to each other `a == b`.  
   
 ```go
 package main


### PR DESCRIPTION
I wonder why there is this int list in this section...

```
+uint8       符号なし8bit整数セット  (0 to 255)
+uint16      符号なし16bit整数セット (0 to 65535)
+uint32      符号なし32bit整数セット (0 to 4294967295)
+uint64      符号なし64bit整数セット (0 to 18446744073709551615)
+
+int8        符号あり8bit整数セット  (-128 to 127)
+int16       符号あり16bit整数セット (-32768 to 32767)
+int32       符号あり32bit整数セット (-2147483648 to 2147483647)
+int64       符号あり64bit整数セット (-9223372036854775808 to 9223372036854775807)
+
+float32     IEEE-754 32bit浮動小数値セット
+float64     IEEE-754 64bit浮動小数値セット
+
+complex64   float32の実数部と虚数部を持つ複素数
+complex128  float64の実数部と虚数部を持つ複素数
+
+byte        uint8の別名
+rune        int32の別名
+```  