### PR TITLE
Typo-Fix: Replace wrong copy/paste

### DIFF
--- a/section_4/4.1.md
+++ b/section_4/4.1.md
@@ -3,28 +3,9 @@
 It's always good to take a look at the language specification and to become familiar and acquainted with the terminology used to talk about a programming language. That way we can be accurate and precise in understanding the language and in representing it and communicating it to others, so it's very important to understand what the people who designed the language were intending. We will have a closer look at the [Go Programming Language Specification](https://golang.org/ref/spec) later on.  
   
 In this section, we're going to take a look at different types in Go. Let's start[Boolean Types](https://golang.org/ref/spec#Boolean_types)  
-
-```
-uint8       the set of all unsigned  8-bit integers (0 to 255)
-uint16      the set of all unsigned 16-bit integers (0 to 65535)
-uint32      the set of all unsigned 32-bit integers (0 to 4294967295)
-uint64      the set of all unsigned 64-bit integers (0 to 18446744073709551615)
-
-int8        the set of all signed  8-bit integers (-128 to 127)
-int16       the set of all signed 16-bit integers (-32768 to 32767)
-int32       the set of all signed 32-bit integers (-2147483648 to 2147483647)
-int64       the set of all signed 64-bit integers (-9223372036854775808 to 9223372036854775807)
-
-float32     the set of all IEEE-754 32-bit floating-point numbers
-float64     the set of all IEEE-754 64-bit floating-point numbers
-
-complex64   the set of all complex numbers with float32 real and imaginary parts
-complex128  the set of all complex numbers with float64 real and imaginary parts
-
-byte        alias for uint8
-rune        alias for int32
-```  
-
+  
+A _boolean type_ represents the set of Boolean truth values denoted by the predeclared constants `true` and `false`. The predeclared boolean type is `bool`.  
+  
 A Boolean is a type that can be either `true` or `false`. If we [look up Boolean](https://www.google.ca/search?q=define%3A+boolean&rlz=1C5CHFA_enCA702CA702&oq=define%3A+boolean&aqs=chrome..69i57j69i58.3231j0j7&sourceid=chrome&ie=UTF-8), it is defined as "denoting a system of algebraic notation used to represent logical propositions, especially in computing and electronics," or "a binary variable, having two possible values called “true” and “false.”  
   
 So a Boolean is just that; `true` or `false`. It plays an important role in programming. Booleans allow us to have an expression evaluate down to a Boolean condition (`true` or `false`). And then make a decision based on that condition. So, if something is `true` we can do one thing, and if it's false, we can do something else.  


### PR DESCRIPTION
Remove the numeric type list and add a description of `bool`